### PR TITLE
[FEATURE] Utiliser dans PixAdmin le référentiel coeur configuré

### DIFF
--- a/admin/app/components/common/tubes-selection.js
+++ b/admin/app/components/common/tubes-selection.js
@@ -26,8 +26,8 @@ export default class TubesSelection extends Component {
   }
 
   setDefaultFrameworks() {
-    const pixFramework = this.args.frameworks.find((framework) => framework.name === 'Pix');
-    this.selectedFrameworkIds = [pixFramework.id];
+    const coreFramework = this.args.frameworks.find((framework) => framework.isCore === true);
+    this.selectedFrameworkIds = [coreFramework.id];
   }
 
   get frameworkOptions() {

--- a/admin/app/models/framework.js
+++ b/admin/app/models/framework.js
@@ -2,6 +2,6 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Framework extends Model {
   @attr('string') name;
-
+  @attr('boolean') isCore;
   @hasMany('area') areas;
 }

--- a/admin/mirage/helpers/create-learning-content.js
+++ b/admin/mirage/helpers/create-learning-content.js
@@ -1,5 +1,5 @@
 export function createLearningContent(server) {
-  const framework_f1 = _createFramework(server, 'Pix');
+  const framework_f1 = _createFramework({ server, name: 'Pix', isCore: true });
   const area_f1_a1 = _createArea('area_f1_a1', framework_f1, server);
   const area_f1_a2 = _createArea('area_f1_a2', framework_f1, server);
   const competence_f1_a1_c1 = _createCompetence('competence_f1_a1_c1', area_f1_a1, server);
@@ -14,15 +14,15 @@ export function createLearningContent(server) {
   _createTube('tube_f1_a1_c1_th2_tu1', true, true, thematic_f1_a1_c1_th2, server);
   _createTube('tube_f1_a1_c2_th1_tu1', true, true, thematic_f1_a1_c2_th1, server);
   _createTube('tube_f1_a2_c1_th1_tu1', true, true, thematic_f1_a2_c1_th1, server);
-  const framework_f2 = _createFramework(server, 'Pix + Cuisine');
+  const framework_f2 = _createFramework({ server, name: 'Pix + Cuisine', isCore: false });
   const area_f2_a1 = _createArea('area_f2_a1', framework_f2, server);
   const competence_f2_a1_c1 = _createCompetence('competence_f2_a1_c1', area_f2_a1, server);
   const thematic_f2_a1_c1_th1 = _createThematic('thematic_f2_a1_c1_th1', competence_f2_a1_c1, server);
   _createTube('tube_f2_a1_c1_th1_tu1', false, false, thematic_f2_a1_c1_th1, server);
 }
 
-function _createFramework(server, name) {
-  return server.create('framework', { name, areas: [] });
+function _createFramework({ server, name, isCore }) {
+  return server.create('framework', { name, isCore, areas: [] });
 }
 
 function _createArea(variableName, framework, server) {

--- a/admin/tests/acceptance/authenticated/target-profiles/list_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list_test.js
@@ -76,7 +76,7 @@ module('Acceptance | Target Profiles | List', function (hooks) {
 
       test('it should redirect to target profile creation form on click "Nouveau profil cible"', async function (assert) {
         // given
-        server.create('framework', { id: 'framework', name: 'Pix' });
+        server.create('framework', { id: 'framework', name: 'Pix', isCore: true });
         await visit('/target-profiles/list');
 
         // when

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
@@ -25,7 +25,7 @@ module('Acceptance | Target profile creation', function (hooks) {
       module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
         test('it should be accessible for an authenticated user', async function (assert) {
           // given
-          server.create('framework', { id: 'framework', name: 'Pix' });
+          server.create('framework', { id: 'framework', name: 'Pix', isCore: true });
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
           // when
@@ -37,7 +37,7 @@ module('Acceptance | Target profile creation', function (hooks) {
 
         test('it should set target-profiles menubar item active', async function (assert) {
           // given
-          server.create('framework', { id: 'framework', name: 'Pix' });
+          server.create('framework', { id: 'framework', name: 'Pix', isCore: true });
           await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
 
           // when

--- a/admin/tests/integration/components/common/tubes-selection_test.js
+++ b/admin/tests/integration/components/common/tubes-selection_test.js
@@ -56,7 +56,7 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
       }),
     ];
 
-    const frameworks = [store.createRecord('framework', { id: 'frameworkId', name: 'Pix', areas })];
+    const frameworks = [store.createRecord('framework', { id: 'frameworkId', name: 'Pix', areas, isCore: true })];
     this.set('frameworks', frameworks);
 
     const onChangeFunction = sinon.stub();

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form_test.js
@@ -30,7 +30,7 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
     onCancel = sinon.stub();
 
     const store = this.owner.lookup('service:store');
-    const frameworks = [store.createRecord('framework', { id: 'framework1', name: 'Pix', areas: [] })];
+    const frameworks = [store.createRecord('framework', { id: 'framework1', name: 'Pix', areas: [], isCore: true })];
 
     this.set('targetProfile', targetProfile);
     this.set('onSubmit', onSubmitWrapper);

--- a/admin/tests/unit/components/common/tubes-selection_test.js
+++ b/admin/tests/unit/components/common/tubes-selection_test.js
@@ -12,7 +12,7 @@ module('Unit | Component | common/tubes-selection', function (hooks) {
   hooks.beforeEach(function () {
     component = createComponent('component:common/tubes-selection', {
       frameworks: [
-        { name: 'Pix', id: 'id1' },
+        { name: 'Pix', id: 'id1', isCore: true },
         { name: 'framework2', id: 'id2' },
       ],
       onChange: sinon.stub(),
@@ -38,7 +38,7 @@ module('Unit | Component | common/tubes-selection', function (hooks) {
       const result = component.selectedFrameworks;
 
       // then
-      assert.deepEqual(result, [{ name: 'Pix', id: 'id1' }]);
+      assert.deepEqual(result, [{ name: 'Pix', id: 'id1', isCore: true }]);
     });
   });
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -353,6 +353,7 @@ const configuration = (function () {
 
     config.lcms.apiKey = 'test-api-key';
     config.lcms.url = 'https://lcms-test.pix.fr/api';
+    config.lcms.coreFrameworkName = 'Core';
 
     config.domain.tldFr = '.fr';
     config.domain.tldOrg = '.org';

--- a/api/lib/domain/models/Framework.js
+++ b/api/lib/domain/models/Framework.js
@@ -1,8 +1,11 @@
+import { constants } from '../constants.js';
+
 class Framework {
   constructor({ id, name, areas }) {
     this.id = id;
     this.name = name;
     this.areas = areas;
+    this.isCore = this.name === constants.CORE_FRAMEWORK_NAME;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/framework-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/framework-serializer.js
@@ -5,7 +5,7 @@ const { Serializer } = jsonapiSerializer;
 const serialize = function (frameworks) {
   return new Serializer('framework', {
     ref: 'id',
-    attributes: ['name', 'areas'],
+    attributes: ['name', 'areas', 'isCore'],
     areas: {
       ref: true,
       ignoreRelationshipData: true,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/framework-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/framework-serializer_test.js
@@ -1,13 +1,14 @@
 import { expect } from '../../../../test-helper.js';
 import * as serializer from '../../../../../lib/infrastructure/serializers/jsonapi/framework-serializer.js';
+import { Framework } from '../../../../../lib/domain/models/Framework.js';
 
 describe('Unit | Serializer | JSONAPI | framework-serializer', function () {
   describe('#serialize', function () {
     it('should return a serialized JSON data object', function () {
       // given
       const frameworks = [
-        { id: 'frameworkId1', name: 'frameworkName1' },
-        { id: 'frameworkId2', name: 'frameworkName2' },
+        new Framework({ id: 'frameworkId1', name: 'Core' }),
+        new Framework({ id: 'frameworkId2', name: 'frameworkName2' }),
       ];
 
       const expectedSerializedResult = {
@@ -15,7 +16,7 @@ describe('Unit | Serializer | JSONAPI | framework-serializer', function () {
           {
             type: 'frameworks',
             id: 'frameworkId1',
-            attributes: { name: 'frameworkName1' },
+            attributes: { name: 'Core', 'is-core': true },
             relationships: {
               areas: {
                 links: {
@@ -27,7 +28,7 @@ describe('Unit | Serializer | JSONAPI | framework-serializer', function () {
           {
             type: 'frameworks',
             id: 'frameworkId2',
-            attributes: { name: 'frameworkName2' },
+            attributes: { name: 'frameworkName2', 'is-core': false },
             relationships: {
               areas: {
                 links: {


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création des profils cible, les catégories ne sont pas affichées.
Cela est dû au fait que les sujets sont recherchés sur le référentiel nommé "Pix" et pas sur celui configuré comme coeur.

## :robot: Proposition
Remonter dans le front la propriété "coeur" déjà définie dans l'API et l'utiliser.

## :rainbow: Remarques
Encore mieux: ajouter dans le référentiel (lcms) cette propriété.

## :100: Pour tester
Lors de la création d'un profil cible, vérifier que la catégorie est affichée.
