### PR TITLE
[FEATURE] Utiliser l'adresse d'expédition précisée dans Brevo

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -11,13 +11,6 @@ import { LOCALE } from '../../domain/constants.js';
 
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
 
-const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
-const PIX_ORGA_NAME_FR = 'Pix Orga - Ne pas répondre';
-const PIX_ORGA_NAME_EN = 'Pix Orga - Noreply';
-const PIX_CERTIF_NAME_FR = 'Pix Certif - Ne pas répondre';
-const PIX_CERTIF_NAME_EN = 'Pix Certif - Noreply';
-const PIX_NAME_FR = 'PIX - Ne pas répondre';
-const PIX_NAME_EN = 'PIX - Noreply';
 const HELPDESK_FRENCH_FRANCE = 'https://support.pix.fr';
 const HELPDESK_ENGLISH_SPOKEN = 'https://support.pix.org/en/support/home';
 const HELPDESK_FRENCH_SPOKEN = 'https://support.pix.org';
@@ -30,7 +23,6 @@ const EMAIL_VERIFICATION_CODE_TAG = 'EMAIL_VERIFICATION_CODE';
 const SCO_ACCOUNT_RECOVERY_TAG = 'SCO_ACCOUNT_RECOVERY';
 
 function sendAccountCreationEmail(email, locale, redirectionUrl) {
-  let pixName;
   let accountCreationEmailSubject;
   let variables;
 
@@ -44,7 +36,6 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
       ...frTranslations['pix-account-creation-email'].params,
     };
 
-    pixName = PIX_NAME_FR;
     accountCreationEmailSubject = frTranslations['pix-account-creation-email'].subject;
   } else if (locale === ENGLISH_SPOKEN) {
     variables = {
@@ -56,7 +47,6 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
       ...enTranslations['pix-account-creation-email'].params,
     };
 
-    pixName = PIX_NAME_EN;
     accountCreationEmailSubject = enTranslations['pix-account-creation-email'].subject;
   } else {
     variables = {
@@ -68,13 +58,10 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
       ...frTranslations['pix-account-creation-email'].params,
     };
 
-    pixName = PIX_NAME_FR;
     accountCreationEmailSubject = frTranslations['pix-account-creation-email'].subject;
   }
 
   return mailer.sendEmail({
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: pixName,
     to: email,
     subject: accountCreationEmailSubject,
     template: mailer.accountCreationTemplateId,
@@ -121,8 +108,6 @@ function sendCertificationResultEmail({
   };
 
   return mailer.sendEmail({
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: `${PIX_NAME_FR} / ${PIX_NAME_EN}`,
     to: email,
     template: mailer.certificationResultTemplateId,
     variables: templateParams,
@@ -132,7 +117,6 @@ function sendCertificationResultEmail({
 function sendResetPasswordDemandEmail({ email, locale, temporaryKey }) {
   const localeParam = locale ? locale : FRENCH_FRANCE;
 
-  let pixName = PIX_NAME_FR;
   let resetPasswordEmailSubject = frTranslations['reset-password-demand-email'].subject;
 
   let templateParams = {
@@ -164,13 +148,10 @@ function sendResetPasswordDemandEmail({ email, locale, temporaryKey }) {
       helpdeskURL: HELPDESK_ENGLISH_SPOKEN,
     };
 
-    pixName = PIX_NAME_EN;
     resetPasswordEmailSubject = enTranslations['reset-password-demand-email'].subject;
   }
 
   return mailer.sendEmail({
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: pixName,
     to: email,
     subject: resetPasswordEmailSubject,
     template: mailer.passwordResetTemplateId,
@@ -180,7 +161,6 @@ function sendResetPasswordDemandEmail({ email, locale, temporaryKey }) {
 
 function sendOrganizationInvitationEmail({ email, organizationName, organizationInvitationId, code, locale, tags }) {
   locale = locale ? locale : FRENCH_FRANCE;
-  let pixOrgaName = PIX_ORGA_NAME_FR;
   let sendOrganizationInvitationEmailSubject = frTranslations['organization-invitation-email'].subject;
 
   let templateParams = {
@@ -221,13 +201,10 @@ function sendOrganizationInvitationEmail({ email, organizationName, organization
       supportUrl: HELPDESK_ENGLISH_SPOKEN,
       ...enTranslations['organization-invitation-email'].params,
     };
-    pixOrgaName = PIX_ORGA_NAME_EN;
     sendOrganizationInvitationEmailSubject = enTranslations['organization-invitation-email'].subject;
   }
 
   return mailer.sendEmail({
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: pixOrgaName,
     to: email,
     subject: sendOrganizationInvitationEmailSubject,
     template: mailer.organizationInvitationTemplateId,
@@ -277,8 +254,6 @@ function sendScoOrganizationInvitationEmail({
   }
 
   return mailer.sendEmail({
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_ORGA_NAME_FR,
     to: email,
     subject: 'Accès à votre espace Pix Orga',
     template: mailer.organizationInvitationScoTemplateId,
@@ -294,7 +269,7 @@ function sendCertificationCenterInvitationEmail({
   code,
   locale,
 }) {
-  let templateParams, fromName, subject;
+  let templateParams, subject;
   const frenchFranceTemplateParams = {
     certificationCenterName,
     pixHomeName: `pix${config.domain.tldFr}`,
@@ -333,26 +308,21 @@ function sendCertificationCenterInvitationEmail({
     case FRENCH_SPOKEN:
       templateParams = frenchSpokenTemplateParams;
       subject = frTranslations['certification-center-invitation-email'].subject;
-      fromName = PIX_CERTIF_NAME_FR;
       break;
 
     case ENGLISH_SPOKEN:
       templateParams = englishSpokenTemplateParams;
-      fromName = PIX_CERTIF_NAME_EN;
       subject = enTranslations['certification-center-invitation-email'].subject;
       break;
 
     default:
       templateParams = frenchFranceTemplateParams;
       subject = frTranslations['certification-center-invitation-email'].subject;
-      fromName = PIX_CERTIF_NAME_FR;
       break;
   }
 
   return mailer.sendEmail({
     subject,
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName,
     to: email,
     template: mailer.certificationCenterInvitationTemplateId,
     variables: templateParams,
@@ -360,7 +330,6 @@ function sendCertificationCenterInvitationEmail({
 }
 
 function sendAccountRecoveryEmail({ email, firstName, temporaryKey }) {
-  const pixName = PIX_NAME_FR;
   const redirectionUrl = `${config.domain.pixApp + config.domain.tldFr}/recuperer-mon-compte/${temporaryKey}`;
   const variables = {
     firstName,
@@ -370,8 +339,6 @@ function sendAccountRecoveryEmail({ email, firstName, temporaryKey }) {
   };
 
   return mailer.sendEmail({
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: pixName,
     to: email,
     subject: 'Récupération de votre compte Pix',
     template: mailer.accountRecoveryTemplateId,
@@ -382,8 +349,6 @@ function sendAccountRecoveryEmail({ email, firstName, temporaryKey }) {
 
 function sendVerificationCodeEmail({ code, email, locale, translate }) {
   const options = {
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME_FR,
     to: email,
     template: mailer.emailVerificationCodeTemplateId,
     tags: [EMAIL_VERIFICATION_CODE_TAG],
@@ -426,8 +391,6 @@ function sendVerificationCodeEmail({ code, email, locale, translate }) {
 
 function sendCpfEmail({ email, generatedFiles }) {
   const options = {
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME_FR,
     to: email,
     template: mailer.cpfEmailTemplateId,
     variables: { generatedFiles },
@@ -440,8 +403,6 @@ function sendNotificationToCertificationCenterRefererForCleaResults({ email, ses
   const formattedSessionDate = dayjs(sessionDate).locale('fr').format('DD/MM/YYYY');
 
   const options = {
-    from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME_FR,
     to: email,
     template: mailer.acquiredCleaResultTemplateId,
     variables: { sessionId, sessionDate: formattedSessionDate },

--- a/api/lib/infrastructure/mailers/SendinblueProvider.js
+++ b/api/lib/infrastructure/mailers/SendinblueProvider.js
@@ -6,17 +6,13 @@ import { config } from '../../config.js';
 import { MailingProviderInvalidEmailError } from './MailingProviderInvalidEmailError.js';
 
 const { mailing } = config;
-function _formatPayload({ to, fromName, from, subject, template, variables, tags }) {
+function _formatPayload({ to, subject, template, variables, tags }) {
   const payload = {
     to: [
       {
         email: to,
       },
     ],
-    sender: {
-      name: fromName,
-      email: from,
-    },
     subject,
     templateId: parseInt(template),
     headers: {

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -18,7 +18,6 @@ import { LOCALE } from '../../../../lib/domain/constants.js';
 const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = LOCALE;
 
 describe('Unit | Service | MailService', function () {
-  const senderEmailAddress = 'ne-pas-repondre@pix.fr';
   const userEmailAddress = 'user@example.net';
 
   beforeEach(function () {
@@ -32,8 +31,6 @@ describe('Unit | Service | MailService', function () {
 
       // given
       const expectedOptions = {
-        from: senderEmailAddress,
-        to: userEmailAddress,
         subject: 'Votre compte Pix a bien été créé',
         template: 'test-account-creation-template-id',
       };
@@ -74,7 +71,6 @@ describe('Unit | Service | MailService', function () {
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
-          expect(options.fromName).to.equal('PIX - Ne pas répondre');
           expect(options.variables).to.include({
             homeName: 'pix.org',
             homeUrl: 'https://pix.org/fr/',
@@ -93,7 +89,6 @@ describe('Unit | Service | MailService', function () {
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
-          expect(options.fromName).to.equal('PIX - Ne pas répondre');
           expect(options.variables).to.include({
             homeName: 'pix.fr',
             homeUrl: 'https://pix.fr',
@@ -112,7 +107,6 @@ describe('Unit | Service | MailService', function () {
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
-          expect(options.fromName).to.equal('PIX - Noreply');
           expect(options.variables).to.include({
             homeName: 'pix.org',
             homeUrl: 'https://pix.org/en-gb/',
@@ -155,8 +149,6 @@ describe('Unit | Service | MailService', function () {
       const options = mailer.sendEmail.firstCall.args[0];
 
       expect(options).to.deep.equal({
-        from: 'ne-pas-repondre@pix.fr',
-        fromName: 'PIX - Ne pas répondre / PIX - Noreply',
         to: userEmailAddress,
         template: 'test-certification-result-template-id',
         variables: {
@@ -183,7 +175,6 @@ describe('Unit | Service | MailService', function () {
   });
 
   describe('#sendResetPasswordDemandEmail', function () {
-    const from = senderEmailAddress;
     const to = userEmailAddress;
     const template = 'test-password-reset-template-id';
     const temporaryKey = 'token';
@@ -192,10 +183,8 @@ describe('Unit | Service | MailService', function () {
       it(`should call mailer with translated texts if locale is ${ENGLISH_SPOKEN}`, async function () {
         // given
         const expectedOptions = {
-          from,
           to,
           template,
-          fromName: 'PIX - Noreply',
           subject: mainTranslationsMapping.en['reset-password-demand-email'].subject,
           variables: {
             locale: ENGLISH_SPOKEN,
@@ -220,10 +209,8 @@ describe('Unit | Service | MailService', function () {
       it(`should call mailer with translated texts if locale is ${FRENCH_SPOKEN}`, async function () {
         // given
         const expectedOptions = {
-          from,
           to,
           template,
-          fromName: 'PIX - Ne pas répondre',
           subject: mainTranslationsMapping.fr['reset-password-demand-email'].subject,
           variables: {
             locale: FRENCH_SPOKEN,
@@ -248,10 +235,8 @@ describe('Unit | Service | MailService', function () {
       it(`should call mailer with translated texts if locale is ${FRENCH_FRANCE}`, async function () {
         // given
         const expectedOptions = {
-          from,
           to,
           template,
-          fromName: 'PIX - Ne pas répondre',
           subject: mainTranslationsMapping.fr['reset-password-demand-email'].subject,
           variables: {
             locale: FRENCH_FRANCE,
@@ -276,10 +261,8 @@ describe('Unit | Service | MailService', function () {
       it(`should call mailer with fr-fr translated texts if locale is undefined`, async function () {
         // given
         const expectedOptions = {
-          from,
           to,
           template,
-          fromName: 'PIX - Ne pas répondre',
           subject: mainTranslationsMapping.fr['reset-password-demand-email'].subject,
           variables: {
             locale: FRENCH_FRANCE,
@@ -324,7 +307,6 @@ describe('Unit | Service | MailService', function () {
 
       // then
       const expectedOptions = {
-        from: senderEmailAddress,
         to: userEmailAddress,
         variables: {
           organizationName,
@@ -332,7 +314,6 @@ describe('Unit | Service | MailService', function () {
       };
       const options = mailer.sendEmail.firstCall.args[0];
 
-      expect(options.from).to.equal(expectedOptions.from);
       expect(options.to).to.equal(expectedOptions.to);
       expect(options.variables.organizationName).to.equal(expectedOptions.variables.organizationName);
     });
@@ -393,7 +374,6 @@ describe('Unit | Service | MailService', function () {
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
-          expect(options.fromName).to.equal('Pix Orga - Ne pas répondre');
           expect(options.subject).to.equal(mainTranslationsMapping.fr['organization-invitation-email'].subject);
           expect(options.variables).to.include({
             pixHomeName: 'pix.org',
@@ -416,7 +396,6 @@ describe('Unit | Service | MailService', function () {
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
-          expect(options.fromName).to.equal('Pix Orga - Ne pas répondre');
           expect(options.subject).to.equal(mainTranslationsMapping.fr['organization-invitation-email'].subject);
           expect(options.variables).to.include({
             pixHomeName: 'pix.fr',
@@ -439,7 +418,6 @@ describe('Unit | Service | MailService', function () {
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
-          expect(options.fromName).to.equal('Pix Orga - Ne pas répondre');
           expect(options.subject).to.equal(mainTranslationsMapping.fr['organization-invitation-email'].subject);
           expect(options.variables).to.include({
             pixHomeName: 'pix.fr',
@@ -462,7 +440,6 @@ describe('Unit | Service | MailService', function () {
 
           // then
           const options = mailer.sendEmail.firstCall.args[0];
-          expect(options.fromName).to.equal('Pix Orga - Noreply');
           expect(options.subject).to.equal(mainTranslationsMapping.en['organization-invitation-email'].subject);
           expect(options.variables).to.include({
             pixHomeName: 'pix.org',
@@ -478,8 +455,6 @@ describe('Unit | Service | MailService', function () {
   });
 
   describe('#sendScoOrganizationInvitationEmail', function () {
-    const fromName = 'Pix Orga - Ne pas répondre';
-
     const subject = 'Accès à votre espace Pix Orga';
     const template = 'test-organization-invitation-sco-demand-template-id';
 
@@ -495,8 +470,6 @@ describe('Unit | Service | MailService', function () {
     it('should call mail provider with pix-orga url, organization-invitation id, code and null tags', async function () {
       // given
       const expectedOptions = {
-        from: senderEmailAddress,
-        fromName,
         to: userEmailAddress,
         subject,
         template,
@@ -545,8 +518,6 @@ describe('Unit | Service | MailService', function () {
       expect(sendEmailParameters.subject).to.equal(
         mainTranslationsMapping.fr['certification-center-invitation-email'].subject
       );
-      expect(sendEmailParameters.from).to.equal(senderEmailAddress);
-      expect(sendEmailParameters.fromName).to.equal('Pix Certif - Ne pas répondre');
       expect(sendEmailParameters.to).to.equal('invited@example.net');
       expect(sendEmailParameters.variables).to.include({
         certificationCenterName: 'Centre Pixou',
@@ -578,7 +549,6 @@ describe('Unit | Service | MailService', function () {
         expect(sendEmailParameters.subject).to.equal(
           mainTranslationsMapping.fr['certification-center-invitation-email'].subject
         );
-        expect(sendEmailParameters.fromName).to.equal('Pix Certif - Ne pas répondre');
         expect(sendEmailParameters.variables).to.include({
           certificationCenterName: 'Centre Pixi',
           pixHomeName: 'pix.org',
@@ -610,7 +580,6 @@ describe('Unit | Service | MailService', function () {
         expect(sendEmailParameters.subject).to.equal(
           mainTranslationsMapping.en['certification-center-invitation-email'].subject
         );
-        expect(sendEmailParameters.fromName).to.equal('Pix Certif - Noreply');
         expect(sendEmailParameters.variables).to.include({
           certificationCenterName: 'Centre Pixi',
           pixHomeName: 'pix.org',
@@ -643,8 +612,6 @@ describe('Unit | Service | MailService', function () {
 
       // then
       const expectedOptions = {
-        from: senderEmailAddress,
-        to: email,
         subject: 'Récupération de votre compte Pix',
         template: 'test-account-recovery-template-id',
         tags: ['SCO_ACCOUNT_RECOVERY'],
@@ -756,8 +723,6 @@ describe('Unit | Service | MailService', function () {
 
       // then
       expect(mailer.sendEmail).to.have.been.calledWith({
-        from: 'ne-pas-repondre@pix.fr',
-        fromName: 'PIX - Ne pas répondre',
         to: email,
         template: mailer.cpfEmailTemplateId,
         variables: { generatedFiles },
@@ -781,8 +746,6 @@ describe('Unit | Service | MailService', function () {
 
       // then
       expect(mailer.sendEmail).to.have.been.calledWith({
-        from: 'ne-pas-repondre@pix.fr',
-        fromName: 'PIX - Ne pas répondre',
         to: email,
         template: mailer.acquiredCleaResultTemplateId,
         variables: { sessionId, sessionDate: '01/01/2022' },

--- a/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
+++ b/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
@@ -10,7 +10,6 @@ describe('Unit | Class | SendinblueProvider', function () {
   });
 
   describe('#sendEmail', function () {
-    const senderEmailAddress = 'no-reply@example.net';
     const userEmailAddress = 'user@example.net';
     const templateId = 129291;
 
@@ -34,9 +33,7 @@ describe('Unit | Class | SendinblueProvider', function () {
         it('should call the given sendinblue api instance', async function () {
           // given
           const options = {
-            from: senderEmailAddress,
             to: userEmailAddress,
-            fromName: 'Ne pas repondre',
             subject: 'Creation de compte',
             template: templateId,
           };
@@ -47,10 +44,6 @@ describe('Unit | Class | SendinblueProvider', function () {
                 email: userEmailAddress,
               },
             ],
-            sender: {
-              name: 'Ne pas repondre',
-              email: senderEmailAddress,
-            },
             subject: 'Creation de compte',
             templateId,
             headers: {
@@ -72,9 +65,7 @@ describe('Unit | Class | SendinblueProvider', function () {
             const tags = ['TEST'];
 
             const options = {
-              from: senderEmailAddress,
               to: userEmailAddress,
-              fromName: 'Ne pas repondre',
               subject: 'Creation de compte',
               template: templateId,
               tags,
@@ -86,10 +77,6 @@ describe('Unit | Class | SendinblueProvider', function () {
                   email: userEmailAddress,
                 },
               ],
-              sender: {
-                name: 'Ne pas repondre',
-                email: senderEmailAddress,
-              },
               subject: 'Creation de compte',
               templateId,
               headers: {
@@ -111,9 +98,7 @@ describe('Unit | Class | SendinblueProvider', function () {
             const tags = null;
 
             const options = {
-              from: senderEmailAddress,
               to: userEmailAddress,
-              fromName: 'Ne pas repondre',
               subject: 'Creation de compte',
               template: templateId,
               tags,
@@ -125,10 +110,6 @@ describe('Unit | Class | SendinblueProvider', function () {
                   email: userEmailAddress,
                 },
               ],
-              sender: {
-                name: 'Ne pas repondre',
-                email: senderEmailAddress,
-              },
               subject: 'Creation de compte',
               templateId,
               headers: {
@@ -150,9 +131,7 @@ describe('Unit | Class | SendinblueProvider', function () {
         it('should throw a MailingProviderInvalidEmailError with provider message', async function () {
           // given
           const options = {
-            from: senderEmailAddress,
             to: userEmailAddress,
-            fromName: 'Ne pas repondre',
             subject: 'Creation de compte',
             template: templateId,
           };


### PR DESCRIPTION
## :unicorn: Problème

Nous voulons que l'adresse d'expéditeur des mails envoyés par Pix4Pix soit pix4pix@pix.digital. Or, l'adresse d'expédition (ne-pas-repondre@pix.fr) est précisée en dur dans le code.

## :robot: Proposition

Ne plus transmettre à l'API de Brevo d'informations sur l'expéditeur de manière à ce que l'expéditeur configuré dans le template soit utilisé.

## :rainbow: Remarques

*RAS*

## :100: Pour tester

Envoyer un email et constater que l'expéditeur est celui configuré dans le template.