### PR TITLE
Ne plus avoir le nombre de compétence en dur sur la page profile

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/login-logout.js
@@ -58,7 +58,7 @@ Then(`je suis redirigé vers le profil de {string}`, (firstName) => {
     expect(userName.text()).to.contains(firstName);
   });
   cy.get(".rounded-panel-title").should((title) => {
-    expect(title.text()).to.contains("Vous avez 16 compétences à tester.");
+    expect(title.text()).to.contains("Vous avez 6 compétences à tester.");
   });
 });
 

--- a/mon-pix/app/components/profile-content.hbs
+++ b/mon-pix/app/components/profile-content.hbs
@@ -9,7 +9,7 @@
         <div
           class="rounded-panel-header-text__content rounded-panel-title rounded-panel-header-text__content--first-title"
         >
-          {{t "pages.profile.first-title" htmlSafe=true}}
+          {{t "pages.profile.first-title" numberOfCompetences=@model.profile.numberOfCompetences htmlSafe=true}}
         </div>
       </div>
       <div class="rounded-panel-header__right-wrapper">

--- a/mon-pix/app/models/profile.js
+++ b/mon-pix/app/models/profile.js
@@ -10,4 +10,8 @@ export default class Profile extends Model {
   get areas() {
     return this.scorecards.mapBy('area').uniqBy('code');
   }
+
+  get numberOfCompetences() {
+    return this.scorecards.uniqBy('competenceId').length;
+  }
 }

--- a/mon-pix/tests/unit/models/profile_test.js
+++ b/mon-pix/tests/unit/models/profile_test.js
@@ -38,4 +38,24 @@ module('Unit | Model | Profile model', function (hooks) {
       );
     });
   });
+
+  module('@numberOfCompetences', function () {
+    test('should return the number of unique competences', function (assert) {
+      // given
+      const area1 = store.createRecord('area', { code: 1 });
+      const area2 = store.createRecord('area', { code: 2 });
+
+      const scorecard1 = store.createRecord('scorecard', { area: area1, competenceId: 'rec1' });
+      const scorecard2 = store.createRecord('scorecard', { area: area1, competenceId: 'rec2' });
+      const scorecard3 = store.createRecord('scorecard', { area: area2, competenceId: 'rec3' });
+      const model = store.createRecord('profile');
+      model.scorecards = [scorecard1, scorecard2, scorecard3];
+
+      // when
+      const numberOfCompetences = model.numberOfCompetences;
+
+      // then
+      assert.deepEqual(numberOfCompetences, 3);
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1196,7 +1196,7 @@
           "no-level": "Competence not started"
         }
       },
-      "first-title": "You have 16 competences to test. '<br>'Get your thinking hat on and off we go!",
+      "first-title": "You have {numberOfCompetences} competences to test. '<br>'Get your thinking hat on and off we go!",
       "resume-campaign-banner": {
         "accessibility": {
           "resume": "Resume your customised test",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1196,7 +1196,7 @@
           "no-level": "Compétence non commencée"
         }
       },
-      "first-title": "Vous avez 16 compétences à tester. '<br>'On se concentre et c'est partix&nbsp;!",
+      "first-title": "Vous avez {numberOfCompetences} compétences à tester. '<br>'On se concentre et c'est partix&nbsp;!",
       "resume-campaign-banner": {
         "accessibility": {
           "resume": "Continuer votre parcours",


### PR DESCRIPTION
## :unicorn: Problème
Quelque soit le nombre de compétence, on affichait "16" compétences.

## :robot: Proposition
Regarder le nombre de compétence du profil à afficher

## :rainbow: Remarques

## :100: Pour tester
Regarder la page profile