### PR TITLE
Renseigner la plateforme Pix4Pix dans les emails (création de compte et changement de mot de passe)

### DIFF
--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -31,7 +31,7 @@ describe('Unit | Service | MailService', function () {
 
       // given
       const expectedOptions = {
-        subject: 'Votre compte Pix a bien été créé',
+        subject: 'Votre compte Pix4Pix a bien été créé',
         template: 'test-account-creation-template-id',
       };
 

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -277,7 +277,7 @@
   },
   "pix-account-creation-email": {
     "params": {
-      "title": "Your Pix account has been created!",
+      "title": "Your Pix4Pix account has been created!",
       "askForHelp": "Any questions? We’re here to help, contact us",
       "disclaimer": "If you did not create this account, you can ask its deletion",
       "doNotAnswer": "This is an automated email message, please do not reply.",
@@ -287,7 +287,7 @@
       "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
       "subtitle": "You can now start testing your skills."
     },
-    "subject": "Your Pix account has been created"
+    "subject": "Your Pix4Pix account has been created"
   },
   "reset-password-demand-email": {
     "params": {
@@ -301,7 +301,7 @@
       "resetMyPassword": "Reset my password",
       "weCannotSendYourPassword": "Hello, for security reasons, we cannot send your password by email."
     },
-    "subject": "Pix password reset request"
+    "subject": "Pix4Pix password reset request"
   },
   "verification-code-email": {
     "body": {

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -291,7 +291,7 @@
   },
   "pix-account-creation-email": {
     "params": {
-      "title": "Votre compte Pix a bien été créé !",
+      "title": "Votre compte Pix4Pix a bien été créé !",
       "askForHelp": "Besoin d’aide, contactez-nous",
       "disclaimer": "Si vous n'êtes pas à l’origine de cette création de compte, vous pouvez en demander la suppression",
       "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
@@ -301,7 +301,7 @@
       "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
       "subtitle": "Vous pouvez désormais commencer les tests."
     },
-    "subject": "Votre compte Pix a bien été créé"
+    "subject": "Votre compte Pix4Pix a bien été créé"
   },
   "reset-password-demand-email": {
     "params": {
@@ -315,7 +315,7 @@
       "resetMyPassword": "Définir un nouveau mot de passe",
       "weCannotSendYourPassword": "Bonjour, pour des raisons de sécurité, nous ne vous envoyons pas votre mot de passe par e-mail."
     },
-    "subject": "Demande de réinitialisation de mot de passe Pix"
+    "subject": "Demande de réinitialisation de mot de passe Pix4Pix"
   },
   "verification-code-email": {
     "body": {


### PR DESCRIPTION
🦄 Problème
Notre emails pour creer un nouveau compte et reinitialization de mot de pass utilise Pix et pas Pix4Pix

🤖 Proposition
Modifier les translations fr + en

🌈 Remarques
Pour permettre de paramateriser le nom de platform, un refactor de mail-service est obliger pour ajouter le translation i18n dans l'appel API et tout les utilisations de mailing service.

💯 Pour tester
Essayer de creer un nouveau compte sur PIX et verifier que le welcome email contient Pix4Pix
Cliquer sur oublie mot de pass et verifier que le email pour redemarrer ton mot de pass contient Pix4Pix